### PR TITLE
docs: updated command from mender to mender-update

### DIFF
--- a/01.Get-started/05.Monitor/docs.md
+++ b/01.Get-started/05.Monitor/docs.md
@@ -23,7 +23,7 @@ If you have followed the [get started tutorial](../01.Preparation/docs.md) to pr
 Verify installed dependencies on your device with:
 
 ```bash
-sudo mender --version && sudo mender-monitorctl --version
+sudo mender-update --version && sudo mender-monitorctl --version
 ```
 
 The output should give no errors and print the version of both tools.


### PR DESCRIPTION
In Get started > Monitor your device, updated the command to verify installed dependencies on your device from "mender" to "mender-update".